### PR TITLE
chore: add golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,7 @@ issues:
   max-same-issues: 0
 formatters:
   enable:
-    #- gofumpt
-    #- goimports
+    - gofumpt
+    - goimports
   exclusions:
     generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,46 @@
+version: "2"
+run:
+  tests: false
+linters:
+  enable:
+    - bodyclose
+    - copyloopvar
+    - dupl
+    - errcheck
+    - errorlint
+    #- exhaustive
+    - goconst
+    #- godot
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    #- prealloc
+    #- revive
+    - unconvert
+    - usestdlibvars
+    #- unparam
+    - whitespace
+    - wrapcheck
+  exclusions:
+    rules:
+      - text: '(slog|log)\.\w+'
+        linters:
+          - noctx
+    generated: lax
+    presets:
+      - common-false-positives
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    #- gofumpt
+    #- goimports
+  exclusions:
+    generated: lax

--- a/cmd/govote/main.go
+++ b/cmd/govote/main.go
@@ -59,7 +59,6 @@ func main() {
 		wish.WithIdleTimeout(8*time.Minute),
 		wish.WithMaxTimeout(60*time.Minute),
 	)
-
 	if err != nil {
 		log.Fatal("Failed to create SSH server", "error", err, "host", host, "port", port)
 	}

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,7 +38,11 @@ func CheckServer(addr address.InputAddress) tea.Msg {
 	base.RawQuery = params.Encode()
 
 	// Perform the HTTP GET request
-	res, err := c.Get(base.String())
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, base.String(), nil)
+	if err != nil {
+		return utils.ErrMsg{Err: err}
+	}
+	res, err := c.Do(req)
 	if err != nil {
 		log.Error("Could not perform HTTP GET request", "error", err)
 		return utils.ErrMsg{Err: err}


### PR DESCRIPTION
## Summary
- Add `.golangci.yml` based on [Charm's config](https://github.com/charmbracelet/bubbletea/blob/main/.golangci.yml) with additional linters (`errcheck`, `errorlint`, `copyloopvar`, `dupl`, `usestdlibvars`)
- Fix `noctx` lint issue in `internal/api/handler.go` by replacing `http.Client.Get` with `http.NewRequestWithContext` + `c.Do()`
- Enable `gofumpt` and `goimports` formatters

## Test plan
- [x] Verify `golangci-lint run` passes with 0 issues
- [x] Verify `go build ./cmd/govote` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)