### PR TITLE
fix: prevent API key leak by moving key from URL to header

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,19 +34,22 @@ func CheckServer(addr address.InputAddress) tea.Msg {
 
 	// Query params
 	params := url.Values{}
-	params.Add("key", apiKey)
 	params.Add("address", addr.String())
 	base.RawQuery = params.Encode()
 
-	// Perform the HTTP GET request
+	// Perform the HTTP GET request. The API key goes in a header, never the
+	// URL: a *url.Error stringifies with the full request URL, so a key in the
+	// query string would leak into logs and user-visible error messages.
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, base.String(), nil)
 	if err != nil {
 		return utils.ErrMsg{Err: err}
 	}
+	req.Header.Set("X-Goog-Api-Key", apiKey)
 	res, err := c.Do(req)
 	if err != nil {
 		log.Error("Could not perform HTTP GET request", "error", err)
-		return utils.ErrMsg{Err: err}
+		// Return a generic message: SSH users see this verbatim.
+		return utils.ErrMsg{Err: errors.New("could not reach the election information service")}
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/govote-sh/govote/internal/address"
+	"github.com/govote-sh/govote/internal/secrets"
+	"github.com/govote-sh/govote/internal/utils"
+)
+
+const testAPIKey = "AIzaSyFAKE-SECRET-KEY-DO-NOT-LEAK"
+
+// TestCheckServerDoesNotLeakAPIKeyOnTransportError verifies that when the HTTP
+// request fails at the transport layer, the returned error does not expose the
+// API key. The key is sent in a header rather than the URL precisely so that
+// the *url.Error the client produces (which embeds the full request URL in its
+// message) can never contain it.
+func TestCheckServerDoesNotLeakAPIKeyOnTransportError(t *testing.T) {
+	t.Setenv("API_KEY", testAPIKey)
+	if err := secrets.SetupSecrets(); err != nil {
+		t.Fatalf("SetupSecrets: %v", err)
+	}
+	// Force every outbound request to fail at connect time.
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+
+	msg := CheckServer(address.InputAddress{Street: "1234 W Broad St", City: "Richmond", State: "VA"})
+
+	errMsg, ok := msg.(utils.ErrMsg)
+	if !ok {
+		t.Fatalf("expected utils.ErrMsg, got %T: %v", msg, msg)
+	}
+	if strings.Contains(errMsg.Error(), testAPIKey) {
+		t.Fatalf("API key leaked in error message: %q", errMsg.Error())
+	}
+}


### PR DESCRIPTION
The key was sent as a key= query parameter, so on transport failures http.Client.Do returned a *url.Error whose message embedded the full request URL, key included. That error was logged and rendered verbatim to SSH users.

Send the key via the X-Goog-Api-Key header instead (supported by the googleapis.com frontend and recommended by Google's API key best practices), so no stringified URL can ever contain it. Also stop returning raw transport errors to users; they get a generic message.

Adds a regression test driving CheckServer against a dead proxy and asserting the returned error never contains the key.