### PR TITLE
fix: don't log user home addresses on transport failure

### DIFF
--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -47,7 +47,13 @@ func CheckServer(addr address.InputAddress) tea.Msg {
 	req.Header.Set("X-Goog-Api-Key", apiKey)
 	res, err := c.Do(req)
 	if err != nil {
-		log.Error("Could not perform HTTP GET request", "error", err)
+		// Log the unwrapped error; the *url.Error carries the address-bearing URL.
+		loggedErr := err
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			loggedErr = urlErr.Err
+		}
+		log.Error("Could not perform HTTP GET request", "error", loggedErr)
 		// Return a generic message: SSH users see this verbatim.
 		return utils.ErrMsg{Err: errors.New("could not reach the election information service")}
 	}

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
 
+	"charm.land/log/v2"
 	"github.com/govote-sh/govote/internal/address"
 	"github.com/govote-sh/govote/internal/secrets"
 	"github.com/govote-sh/govote/internal/utils"
@@ -32,5 +35,43 @@ func TestCheckServerDoesNotLeakAPIKeyOnTransportError(t *testing.T) {
 	}
 	if strings.Contains(errMsg.Error(), testAPIKey) {
 		t.Fatalf("API key leaked in error message: %q", errMsg.Error())
+	}
+}
+
+// TestCheckServerDoesNotLogAddressOnTransportError verifies the address (which
+// rides in the request URL) is not logged when the transport fails: the raw
+// *url.Error must be unwrapped before logging.
+func TestCheckServerDoesNotLogAddressOnTransportError(t *testing.T) {
+	t.Setenv("API_KEY", testAPIKey)
+	if err := secrets.SetupSecrets(); err != nil {
+		t.Fatalf("SetupSecrets: %v", err)
+	}
+	// Force every outbound request to fail at connect time.
+	t.Setenv("HTTPS_PROXY", "http://127.0.0.1:9")
+
+	// Capture log output; the default logger is a shared global, so restore it.
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	const (
+		street = "1234 W Broad St"
+		city   = "Richmond"
+	)
+	msg := CheckServer(address.InputAddress{Street: street, City: city, State: "VA"})
+
+	if _, ok := msg.(utils.ErrMsg); !ok {
+		t.Fatalf("expected utils.ErrMsg, got %T: %v", msg, msg)
+	}
+
+	logged := buf.String()
+	if logged == "" {
+		t.Fatal("expected a transport error to be logged, got no log output")
+	}
+	if strings.Contains(logged, street) || strings.Contains(logged, city) {
+		t.Fatalf("user address leaked in server logs: %q", logged)
+	}
+	if strings.Contains(logged, baseURL) {
+		t.Fatalf("request URL leaked in server logs: %q", logged)
 	}
 }


### PR DESCRIPTION
# fix: don't log user home addresses on transport failure

## What

When the Civic API request fails at the transport layer, we logged the raw
error. That error is a `*url.Error`, whose string form embeds the full request
URL — and the URL carries the user's address in the `?address=…` query param.
So every unreachable-API event wrote a home address into the Fly logs.

## User impact & disclosure

I was not actively monitoring the logs, so I did not see any PII. Addresses were
only written on the error path (API unreachable), never during normal use, and
were never displayed or forwarded anywhere. govote keeps no database and
`fly.toml` sets no log drain, so the only copies lived in Fly's built-in log
store, which auto-deletes after 7 days. Any previously-logged address has aged
out (or will within 7 days of deploy); this fix ensures no new ones are written.

## Fix

Unwrap the `*url.Error` and log only its underlying cause (`urlErr.Err` — the
dial/TLS error), dropping the address-bearing URL. The user-facing message was
already generic and is unchanged.